### PR TITLE
py2neo alt download and version bump

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,8 +1,8 @@
 kubernetes
 flask
-py2neo
 prettyprint
 gunicorn
 gevent
 natsort
 https://github.com/datacenter/pyaci/archive/master.zip
+https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz

--- a/app/version.txt
+++ b/app/version.txt
@@ -1,1 +1,1 @@
-Build:  v1.2.0
+Build:  v2.0.0


### PR DESCRIPTION
py2neo is no more, for now I have found a fork we can use but eventually we will have to migrate to something else I fear.